### PR TITLE
Add noarch

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,5 +6,3 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-target_platform:
-- linux-64

--- a/README.md
+++ b/README.md
@@ -18,30 +18,11 @@ Current build status
 ====================
 
 
-<table>
-    
-  <tr>
-    <td>Azure</td>
+<table><tr><td>All platforms:</td>
     <td>
-      <details>
-        <summary>
-          <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26455&branchName=main">
-            <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/shs-cassini-headers-feedstock?branchName=main">
-          </a>
-        </summary>
-        <table>
-          <thead><tr><th>Variant</th><th>Status</th></tr></thead>
-          <tbody><tr>
-              <td>linux_64</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26455&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/shs-cassini-headers-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_" alt="variant">
-                </a>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </details>
+      <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26455&branchName=main">
+        <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/shs-cassini-headers-feedstock?branchName=main">
+      </a>
     </td>
   </tr>
 </table>

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -14,9 +14,6 @@ build:
   number: 1
   noarch: generic
   script: build.sh
-  skip:
-    - win
-    - osx
 
 tests:
   - script:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -11,7 +11,8 @@ source:
     sha256: db338e6af8bff8c5acd0556bbad81eba5365db9eec918d46021483861a386792  # Tagged release 12.0.1, aligns with spec version 1.1.1
 
 build:
-  number: 0
+  number: 1
+  noarch: generic
   script: build.sh
   skip:
     - win


### PR DESCRIPTION
This PR updates the shs-cassini-headers recipe to use noarch: generic

@conda-forge-admin, please rerender

Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
